### PR TITLE
Change Jupyter server spawn implementation to inherit user PATH

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -19,7 +19,6 @@ import {
 
 import * as path from 'path';
 import * as url from 'url';
-//import * as log from 'electron-log';
 
 class JupyterServer {
     /**

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -19,6 +19,7 @@ import {
 
 import * as path from 'path';
 import * as url from 'url';
+//import * as log from 'electron-log';
 
 class JupyterServer {
     /**
@@ -38,7 +39,8 @@ class JupyterServer {
             let urlRegExp = /http:\/\/localhost:\d+\/\?token=\w+/g;
             let tokenRegExp = /token=\w+/g;
             let baseRegExp = /http:\/\/localhost:\d+\//g;
-            this.nbServer = spawn('jupyter', ['notebook', '--no-browser', '--port', String(port)]);
+
+            this.nbServer = spawn('bash', ['-i']);
 
             this.nbServer.on('error', (err: Error) => {
                 this.nbServer.stderr.removeAllListeners();
@@ -60,6 +62,8 @@ class JupyterServer {
                 }
                 resolve(serverData);
             });
+
+            this.nbServer.stdin.write('exec jupyter notebook --no-browser --port ' + port + '\n');
         });
     }
 


### PR DESCRIPTION
This PR fixes jupyterlab/jupyterlab_app#55. It changes the way the Jupyter server is spawned so it can inherit the user PATH environment variable. Instead of spawning the Jupyter notebook server directly from the main process, we spawn a shell in interactive mode, which forces .bashrc to be executed. We then pipe a command to the shell that starts the notebook server.